### PR TITLE
Reading HiGHS solution from stdout to fix #5

### DIFF
--- a/src/post.js
+++ b/src/post.js
@@ -33,12 +33,16 @@ Module["solve"] = function (model_str) {
   const status = UTF8ToString(
     _Highs_highsModelStatusToChar(highs, _Highs_getModelStatus(highs, 0))
   );
+  // Flush the content of stdout in order to have a clean stream before writing the solution in it
+  stdout_lines.length = 0;
   assert_ok(
-    () => Module.Highs_writeSolutionPretty(highs, "/dev/stderr"),
+    () => Module.Highs_writeSolutionPretty(highs, ""),
     "write and extract solution"
   );
   _Highs_destroy(highs);
-  const output = parseResult(stderr_lines, status);
+  const output = parseResult(stdout_lines, status);
+  // Flush the content of stdout and stderr because these streams are not used anymore
+  stdout_lines.length = 0;
   stderr_lines.length = 0;
   return output;
 };


### PR DESCRIPTION
As detailled in the issue, it seems providing an FS API stream (`/dev/stderr` or `/dev/stdout`) or even a real file to the HiGHS method whichs writes the solution ultimately leads to an error in the FS API (error number 33, too many file descriptors used).

The workaround implemented here is to not provide any stream or file to HiGHS, in which case it outputs the results directly to `stdout`.

While the expected behaviour should be the same than if the FS API stream `/dev/stdout` was provided, it is not: there are no errors related to the FS API anymore.

--

With this change, the issue reported disappears, and even 10 000 consecutive executions of `high.solve()` are fine.

Fixes #5 