### PR TITLE
Add support for quadratic programs

### DIFF
--- a/src/post.js
+++ b/src/post.js
@@ -86,9 +86,8 @@ Module["solve"] = function (model_str, highs_options) {
     "write and extract solution"
   );
   _Highs_destroy(highs);
-  const isQuadratic = model_str.indexOf("[") !== -1;
   // The final four lines of the output (whose contents are the objective value) are removed before parsing
-  const output = parseResult(stdout_lines.slice(0, -4), status, isQuadratic);
+  const output = parseResult(stdout_lines.slice(0, -4), status);
   // Flush the content of stdout and stderr because these streams are not used anymore
   stdout_lines.length = 0;
   stderr_lines.length = 0;
@@ -151,30 +150,48 @@ function lineToObj(headers, line) {
  * @param {import("../types").HighsModelStatus} status status
  * @returns {import("../types").HighsSolution} The solution
  */
-function parseResult(lines, status, isQuadratic) {
+function parseResult(lines, status) {
   if (lines.length < 3)
     throw new Error("Unable to parse solution. Too few lines.");
-  let headers = lineValues(lines[1]);
-  // There is no value for "status" and "dual" when the problem contains integer variables,
-  // and no value for "status" when the problem is a quadratic program.
-  const isLinear = !isQuadratic && headers.indexOf("Type") === -1;
-  const infeasible = status === "Infeasible";
-  const headersFilter = h => !(
-    (infeasible && (h === "Status" || h === "Dual" || h === "Primal")) ||
-    (!isLinear && !isQuadratic && (h === "Status" || h === "Dual")) ||
-    (isQuadratic && (h === "Status"))
-  );
-  headers = headers.filter(headersFilter);
+
+  let headers = headersForNonEmptyColumns(lines[1], lines[2]);
+  
+  // We identity whether the problem is a QP by the available headers: For infeasible
+  // problems, "Status", "Dual", and "Primal" are missing, for integer linear programs,
+  // "Status" and "Dual" are missing, and for QPs, only "Status" is missing
+  const isQuadratic = !headers.includes("Status") && headers.includes("Dual");
+  const isLinear = !headers.includes("Type") && !isQuadratic;
+
   var result = { "Status": status, "Columns": {}, "Rows": [], "IsLinear": isLinear, "IsQuadratic": isQuadratic };
   for (var i = 2; lines[i] != "Rows"; i++) {
     const obj = lineToObj(headers, lines[i]);
     result["Columns"][obj["Name"]] = obj;
   }
-  headers = lineValues(lines[i + 1]).filter(headersFilter);
-  for (var j = i + 2; j < lines.length; j++) {
-    result["Rows"].push(lineToObj(headers, lines[j]));
+
+  if (lines.length > i + 2) {
+    headers = headersForNonEmptyColumns(lines[i + 1], lines[i + 2]);
+    for (var j = i + 2; j < lines.length; j++) {
+      result["Rows"].push(lineToObj(headers, lines[j]));
+    }
   }
   return result;
+}
+
+/**
+ * Finds the non headers for non-empty columns in a HiGHS output
+ * @param {string} headerLine The line containing the header names
+ * @param {string} firstDataLine The line immediately below the header line
+ * @returns {string[]} The headers for which there is data available
+ */
+function headersForNonEmptyColumns(headerLine, firstDataLine) {
+  // Headers can correspond to empty columns. The contents of a column can be left or right
+  // aligned, so we determine if a given header should be included by looking at whether
+  // the row immediately below the header has any contents.
+  const headers = [...headerLine.matchAll(/[^\s]+/g)];
+  const headerStarts = headers.map(h => h.index);
+  const headerEnds = headers.map(h => h.index + h[0].length - 1);
+  return headers.map(x => x[0]).filter(
+    (_, i) => firstDataLine[headerStarts[i]] !== ' ' || firstDataLine[headerEnds[i]] !== ' ');
 }
 
 function assert_ok(fn, action) {

--- a/src/post.js
+++ b/src/post.js
@@ -184,14 +184,13 @@ function parseResult(lines, status) {
  * @returns {string[]} The headers for which there is data available
  */
 function headersForNonEmptyColumns(headerLine, firstDataLine) {
-  // Headers can correspond to empty columns. The contents of a column can be left or right
-  // aligned, so we determine if a given header should be included by looking at whether
-  // the row immediately below the header has any contents.
-  const headers = [...headerLine.matchAll(/[^\s]+/g)];
-  const headerStarts = headers.map(h => h.index);
-  const headerEnds = headers.map(h => h.index + h[0].length - 1);
-  return headers.map(x => x[0]).filter(
-    (_, i) => firstDataLine[headerStarts[i]] !== ' ' || firstDataLine[headerEnds[i]] !== ' ');
+	// Headers can correspond to empty columns. The contents of a column can be left or right
+	// aligned, so we determine if a given header should be included by looking at whether
+	// the row immediately below the header has any contents.
+	return [...headerLine.matchAll(/[^\s]+/g)].filter(match =>
+		firstDataLine[match.index] !== ' ' ||
+		firstDataLine[match.index + match[0].length - 1] !== ' '
+	).map(match => match[0])
 }
 
 function assert_ok(fn, action) {

--- a/tests/test.js
+++ b/tests/test.js
@@ -155,6 +155,42 @@ function test_integer_problem(Module) {
   });
 }
 
+function test_case_with_no_constraints(Module) {
+  const sol = Module.solve(`Maximize
+  obj: x1 + 2 x2
+ Bounds
+  0 <= x1 <= 40
+  2 <= x2 <= 3
+ End`);
+  assert.deepStrictEqual(sol, {
+    "IsLinear": true,
+    "IsQuadratic": false,
+    "Status": "Optimal",
+    "Columns": {
+      "x1": {
+        "Index": 0,
+        "Status": "UB",
+        "Lower": 0,
+        "Upper": 40,
+        "Primal": 40,
+        "Dual": 1,
+        "Name": "x1"
+      },
+      "x2": {
+        "Index": 1,
+        "Status": "UB",
+        "Lower": 2,
+        "Upper": 3,
+        "Primal": 3,
+        "Dual": 2,
+        "Name": "x2"
+      }
+    },
+    "Rows": [],
+  })
+
+}
+
 
 /**
  * @param {import("../types").Highs} Module
@@ -230,6 +266,38 @@ function test_infeasible(Module) {
 }
 
 
+/**
+ * @param {import("../types").Highs} Module
+ */
+ function test_infeasible_ilp(Module) {
+  const sol = Module.solve(`Maximize
+  a 
+subject to
+  a >= 1
+bounds
+  a <= 0
+General
+  a
+end`);
+  assert.deepStrictEqual(sol, {
+    IsLinear: false,
+    IsQuadratic: false,
+    Status: 'Infeasible',
+    Columns: {
+      a: {
+        Index: 0,
+        Lower: 0,
+        Upper: 0,
+        Type: 'Integer',
+        Name: 'a'
+      }
+    },
+    Rows: [
+      { Index: 0, Lower: 1, Upper: Infinity }
+    ]
+  });
+}
+
 
 /**
  * @param {import("../types").Highs} Module
@@ -278,9 +346,11 @@ async function test() {
   test_invalid_model(Module);
   test_options(Module);
   test_integer_problem(Module);
+  test_case_with_no_constraints(Module);
   test_quadratic_program(Module);
   test_quadratic_program_not_positive_semidefinite(Module);
   test_infeasible(Module);
+  test_infeasible_ilp(Module);
   test_unbounded(Module);
   test_big(Module);
   test_many_solves(Module);


### PR DESCRIPTION
This adds support for solving quadratic programs on the same footing as (mixed integer) linear programs. HiGHS itself supports these programs out of the box, so the main change necessary here is to ensure that all outputs are parsed as expected.

One complicating factor is that the collection of populated columns is different: Just like outputs for infeasible problems lack some of the columns, for quadratic programs the "Status" column is not populated. We take care of this by following the same pattern as for the other cases, simply filtering the header before parsing the result; to do so, we keep track of whether we are looking at a quadratic program and as a bonus, we add a property called `IsQuadratic` to the output.

A couple of tests are added to ensure that this works as expected. As it turns out, the version of HiGHS added as a submodule produces incorrect results for one of the test cases, by producing non-error output for a problem whose Hessian isn't positive semi-definite. To get around this problem, we simply update the HiGHS submodule to the most recent version and check that the problematic problem is indeed problematic.

Another change since the previously bundled version of HiGHS is that the output now contains the value of the objective as well. While this seems like something that could be useful to include in the JavaScript output object as well, here we just opt to remove the final four lines before parsing, leaving the parsing of the objective value as an exercise for the future.

Some questions here:
* Is `const isQuadratic = model_str.indexOf("[") !== -1;` really the best way to check if this is a QP?
* We say that `isLinear` is `false` when `isQuadratic` is `true`; are those the expected semantics?

This closes gh-13.