### PR TITLE
Avoid treating loadModel warnings as errors

### DIFF
--- a/src/post.js
+++ b/src/post.js
@@ -59,19 +59,10 @@ const MODEL_STATUS_CODES = {
 Module["solve"] = function (model_str, highs_options) {
   FS.writeFile(MODEL_FILENAME, model_str);
   const highs = _Highs_create();
-
-  const readErrorMessage = "Unable to read LP model (see http://web.mit.edu/lpsolve/doc/CPLEX-format.htm)";
-  let readStatus;
-  try {
-    readStatus = Module.Highs_readModel(highs, MODEL_FILENAME);
-  } catch (err) {
-    throw new Error(readErrorMessage);
-  }
-  // Also check for HighsStatus::kError (-1)
-  if (readStatus === -1) {
-    throw new Error(readErrorMessage);
-  }
-
+  assert_ok(
+    () => Module.Highs_readModel(highs, MODEL_FILENAME),
+    "read LP model (see http://web.mit.edu/lpsolve/doc/CPLEX-format.htm)"
+  );
   const options = highs_options || {};
   for (const option_name in options) {
     const option_value = options[option_name];
@@ -209,6 +200,8 @@ function assert_ok(fn, action) {
   } catch (e) {
     err = e;
   }
-  if (err !== 0)
+  // Allow HighsStatus::kWarning (0) and HighsStatus::kWarning (1) but 
+  // disallow other values, such as e.g. HighsStatus::kError (-1).
+  if (!(err in [0, 1]))
     throw new Error("Unable to " + action + ". HiGHS error " + err);
 }

--- a/src/post.js
+++ b/src/post.js
@@ -202,6 +202,6 @@ function assert_ok(fn, action) {
   }
   // Allow HighsStatus::kOk (0) and HighsStatus::kWarning (1) but 
   // disallow other values, such as e.g. HighsStatus::kError (-1).
-  if (err !== 0 || err !== 1)
+  if (err !== 0 && err !== 1)
     throw new Error("Unable to " + action + ". HiGHS error " + err);
 }

--- a/src/post.js
+++ b/src/post.js
@@ -59,10 +59,19 @@ const MODEL_STATUS_CODES = {
 Module["solve"] = function (model_str, highs_options) {
   FS.writeFile(MODEL_FILENAME, model_str);
   const highs = _Highs_create();
-  assert_ok(
-    () => Module.Highs_readModel(highs, MODEL_FILENAME),
-    "read LP model (see http://web.mit.edu/lpsolve/doc/CPLEX-format.htm)"
-  );
+
+  const readErrorMessage = "Unable to read LP model (see http://web.mit.edu/lpsolve/doc/CPLEX-format.htm)";
+  let readStatus;
+  try {
+    readStatus = Module.Highs_readModel(highs, MODEL_FILENAME);
+  } catch (err) {
+    throw new Error(readErrorMessage);
+  }
+  // Also check for HighsStatus::kError (-1)
+  if (readStatus === -1) {
+    throw new Error(readErrorMessage);
+  }
+
   const options = highs_options || {};
   for (const option_name in options) {
     const option_value = options[option_name];

--- a/src/post.js
+++ b/src/post.js
@@ -200,8 +200,8 @@ function assert_ok(fn, action) {
   } catch (e) {
     err = e;
   }
-  // Allow HighsStatus::kWarning (0) and HighsStatus::kWarning (1) but 
+  // Allow HighsStatus::kOk (0) and HighsStatus::kWarning (1) but 
   // disallow other values, such as e.g. HighsStatus::kError (-1).
-  if (!(err in [0, 1]))
+  if (err !== 0 || err !== 1)
     throw new Error("Unable to " + action + ". HiGHS error " + err);
 }

--- a/tests/test.js
+++ b/tests/test.js
@@ -328,6 +328,56 @@ function test_unbounded(Module) {
 /**
  * @param {import("../types").Highs} Module
  */
+function test_read_model_warning(Module) {
+  // See https://github.com/lovasoa/highs-js/issues/17
+  const sol = Module.solve(`Minimize
+obj: x1
+Subject To
+c1: 1 x0 + 1 x1 = 1
+Bounds
+0 <= x1 <= 1
+1.1 <= x2 <= 1
+End`);
+  assert.deepStrictEqual(sol, {
+    IsLinear: true,
+    IsQuadratic: false,
+    Status: 'Infeasible',
+    Columns: {
+      x0: {
+        Index: 1,
+        Lower: 0,
+        Name: 'x0',
+        Upper: Infinity
+      },
+      x1: {
+        Index: 0,
+        Lower: 0,
+        Name: 'x1',
+        Upper: 1
+      },
+      x2: {
+        Index: 2,
+        Lower: 1.1,
+        Name: 'x2',
+        Upper: 1
+      }
+    },
+    IsLinear: true,
+    IsQuadratic: false,
+    Rows: [
+      {
+        Index: 0,
+        Lower: 1,
+        Upper: 1
+      }
+    ]
+  });
+}
+
+
+/**
+ * @param {import("../types").Highs} Module
+ */
 function test_big(Module) {
   const pb = fs.readFileSync(__dirname + "/life_goe.mod.lp");
   Module.solve(pb);
@@ -354,6 +404,7 @@ async function test() {
   test_unbounded(Module);
   test_big(Module);
   test_many_solves(Module);
+  test_read_model_warning(Module);
   console.log("test succeeded");
 }
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -402,9 +402,9 @@ async function test() {
   test_infeasible(Module);
   test_infeasible_ilp(Module);
   test_unbounded(Module);
+  test_read_model_warning(Module);
   test_big(Module);
   test_many_solves(Module);
-  test_read_model_warning(Module);
   console.log("test succeeded");
 }
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -342,6 +342,7 @@ End`);
     IsLinear: true,
     IsQuadratic: false,
     Status: 'Infeasible',
+    ObjectiveValue: 0,
     Columns: {
       x0: {
         Index: 1,


### PR DESCRIPTION
The C API function `readModel` can return one of three values, cf.

```c
enum class HighsStatus { kError = -1, kOk = 0, kWarning = 1 };
```

and in the corresponding piece of JavaScript, `assert_ok` would make the requirement that result is 0. Here, we change that to require only that the result is not -1, thus allowing `solve` to continue in case the loading of the model causes a warning.

A different approach here could have been to stick to `assert_ok`, but give it an argument a la `allowedReturnValues`.

Note also that it is possible for `readModel` to error completely (as is the case for the test `test_invalid_model`), so we make sure to explicitly check for that as well.

It could be useful enough to actually provide the warning message to the user somehow, but figuring out what the warning message is might be some work; it is not part of the pretty output, for example.

This closes #17.