### PR TITLE
Make submodule cloneable without a GitHub account

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "HiGHS"]
 	path = HiGHS
-	url = git@github.com:ERGO-Code/HiGHS.git
+	url = https://github.com/ERGO-Code/HiGHS.git


### PR DESCRIPTION
This is required in CI settings where not GitHub account is set up.