### PR TITLE
fix: types.d.ts has incorrect solution type

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -293,7 +293,7 @@ type HighsSolution =
 type GenericHighsSolution<IsLinear extends boolean, ColType, RowType, Status extends HighsModelStatus = HighsModelStatus> = {
   IsLinear: IsLinear,
   Status: Status;
-  Objective: number;
+  ObjectiveValue: number;
   Columns: Record<string, ColType>;
   Rows: RowType[];
 };


### PR DESCRIPTION
Thank you for creating this project, it has been so simple to integrate it into a Vite/Vue3/Typescript project.

I found an issue today related to the type of the returned solution object. The commit basically speaks for itself.