### PR TITLE
Update HiGHS to v1.8.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install cmake
 
 RUN git clone https://github.com/emscripten-core/emsdk.git /emsdk && \
-    sudo /emsdk/emsdk install 3.1.24 && \
-    sudo /emsdk/emsdk activate 3.1.24 && \
+    sudo /emsdk/emsdk install 3.1.71 && \
+    sudo /emsdk/emsdk activate 3.1.71 && \
     sudo ln -s /emsdk/upstream/emscripten /usr/share/emscripten
 
 ENV PATH="$PATH:/emsdk:/emsdk/upstream/emscripten:/emsdk/node/20.18.0_64bit/bin"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,8 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.205.2/containers/javascript-node/.devcontainer/base.Dockerfile
 
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
-ARG VARIANT="16-bullseye"
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+ARG VARIANT="20-bookworm"
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:1-${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
@@ -13,7 +13,7 @@ RUN git clone https://github.com/emscripten-core/emsdk.git /emsdk && \
     sudo /emsdk/emsdk activate 3.1.24 && \
     sudo ln -s /emsdk/upstream/emscripten /usr/share/emscripten
 
-ENV PATH="$PATH:/emsdk:/emsdk/upstream/emscripten:/emsdk/node/14.18.2_64bit/bin"
+ENV PATH="$PATH:/emsdk:/emsdk/upstream/emscripten:/emsdk/node/20.18.0_64bit/bin"
 
 RUN cd /emsdk/upstream/emscripten/ && sudo npm install acorn google-closure-compiler
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,23 +7,26 @@
 		// Update 'VARIANT' to pick a Node version: 16, 14, 12.
 		// Append -bullseye or -buster to pin to an OS version.
 		// Use -bullseye variants on local arm64/Apple Silicon.
-		"args": { "VARIANT": "16-bullseye" }
+		"args": {
+			"VARIANT": "20-bookworm"
+		}
 	},
-
-	// Set *default* container specific settings.json values on container create.
-	"settings": {},
-
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"dbaeumer.vscode-eslint"
-	],
-
+	"customizations": {
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {
+				"eslint.format.enable": true
+			},
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"esbenp.prettier-vscode"
+			]
+		}
+	},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "yarn install",
-
+	"postCreateCommand": "npm install",
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node"
 }

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,11 +7,11 @@ jobs:
     name: Continuous Integration
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
-      - uses: mymindstorm/setup-emsdk@v12
-        with: { version: "3.1.47" }
+      - uses: mymindstorm/setup-emsdk@v14
+        with: { version: "3.1.71" }
       - run: npm ci
       - name: build
         run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,11 @@ jobs:
     name: Create a release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
-      - uses: mymindstorm/setup-emsdk@v12
-        with: { version: "3.1.47" }
+      - uses: mymindstorm/setup-emsdk@v14
+        with: { version: "3.1.71" }
       - run: npm ci
       - name: build
         run: npm run build
@@ -23,13 +23,13 @@ jobs:
         run: npm test
       - run: cp build/highs.* demo/
       - name: Deploy demo 🚀
-        uses: JamesIves/github-pages-deploy-action@4.1.0
+        uses: JamesIves/github-pages-deploy-action@4.6.8
         with:
           branch: gh-pages
           folder: demo
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1.0.0
+        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ mkdir -p build
 cd build
 
 # Run emconfigure with the normal configure command as an argument.
-emcmake cmake ../HiGHS -DOPENMP=OFF -DFAST_BUILD=OFF -DSHARED=OFF
+emcmake cmake ../HiGHS -DZLIB=OFF -DFAST_BUILD=OFF -DBUILD_SHARED_LIBS=OFF
 
 # Run emmake with the normal make to generate wasm object files.
 emmake make -j8 libhighs
@@ -22,7 +22,7 @@ emmake make -j8 libhighs
 export EMCC_CLOSURE_ARGS="--jscomp_off=checkTypes"
 emcc -O3 \
 	-s EXPORTED_FUNCTIONS="@$root/exported_functions.json" \
-	-s EXTRA_EXPORTED_RUNTIME_METHODS="['cwrap']" \
+	-s EXPORTED_RUNTIME_METHODS="['cwrap']" \
 	-s MODULARIZE=1 \
 	-s ALLOW_MEMORY_GROWTH=1 \
 	-flto \

--- a/src/post.js
+++ b/src/post.js
@@ -60,7 +60,7 @@ var /** @type {()=>Highs} */ _Highs_create,
 /**
  * Solve a model in the CPLEX LP file format.
  * @param {string} model_str The problem to solve in the .lp format
- * @param {undefined | import("../types").HighsOptions} highs_options Options to pass the solver. See https://github.com/ERGO-Code/HiGHS/blob/c70854d/src/lp_data/HighsOptions.h
+ * @param {undefined | import("../types").HighsOptions} highs_options Options to pass the solver. See https://github.com/ERGO-Code/HiGHS/blob/v1.8.0/src/lp_data/HighsOptions.h
  * @returns {import("../types").HighsSolution} The solution
  */
 Module["solve"] = function (model_str, highs_options) {

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,7 +1,7 @@
 /** @type {import("../types").default} */
-const highs = require("../build/highs.js");
+const highs = require('../build/highs.js');
 const assert = require('assert').strict;
-const fs = require("fs");
+const fs = require('fs');
 
 const PROBLEM = `Maximize
  obj: x1 + 2 x2 + 4 x3 + x4
@@ -91,7 +91,7 @@ const SOLUTION = {
 };
 
 /**
- * @param {import("../types").Highs} Module 
+ * @param {import("../types").Highs} Module
  */
 function test_optimal(Module) {
   const sol = Module.solve(PROBLEM);
@@ -103,11 +103,11 @@ function test_optimal(Module) {
  */
 function test_options(Module) {
   const sol = Module.solve(PROBLEM, {
-    "primal_feasibility_tolerance": 1e-9,// option type: double
-    "time_limit": 1000, // option type: double
-    "allowed_cost_scale_factor": 2, // option type: integer
-    "use_implied_bounds_from_presolve": true,
-    "presolve": "off",
+    primal_feasibility_tolerance: 1e-9, // option type: double
+    time_limit: 1000, // option type: double
+    allowed_cost_scale_factor: 2, // option type: integer
+    use_implied_bounds_from_presolve: true,
+    presolve: 'off'
   });
   assert.deepStrictEqual(sol, SOLUTION);
 }
@@ -119,13 +119,15 @@ function test_empty_model(Module) {
   // Arguably, this example should not be considered valid at all, but
   // HiGHS parses it as an empty model; see
   // https://github.com/ERGO-Code/HiGHS/issues/1451
-  const sol = Module.solve("blah blah not a good file");
+  const sol = Module.solve(`Minimize
+    42
+  End`);
   assert.deepStrictEqual(sol, {
-      Columns: {},
-      ObjectiveValue: 0,
-      Rows: [],
-      Status: 'Empty'
-    });
+    Columns: {},
+    ObjectiveValue: 0,
+    Rows: [],
+    Status: 'Empty'
+  });
 }
 
 /**
@@ -133,10 +135,11 @@ function test_empty_model(Module) {
  */
 function test_invalid_model(Module) {
   assert.throws(
-    (_) => Module.solve(`Minimize
+    _ =>
+      Module.solve(`Minimize
         ] 2 [
       End`),
-      /Unable to read LP model/
+    /Unable to read LP model/
   );
 }
 
@@ -172,9 +175,7 @@ function test_integer_problem(Module) {
         Name: 'b'
       }
     },
-    Rows: [
-      { Index: 0, Lower: 6.5, Upper: Infinity, Primal: 6.5, Name: 'c1' }
-    ]
+    Rows: [{ Index: 0, Lower: 6.5, Upper: Infinity, Primal: 6.5, Name: 'c1' }]
   });
 }
 
@@ -186,35 +187,33 @@ function test_case_with_no_constraints(Module) {
   2 <= x2 <= 3
  End`);
   assert.deepStrictEqual(sol, {
-    "Status": "Optimal",
-    "ObjectiveValue": 46,
-    "Columns": {
-      "x1": {
-        "Index": 0,
-        "Status": "UB",
-        "Lower": 0,
-        "Upper": 40,
-        "Type": "Continuous",
-        "Primal": 40,
-        "Dual": 1,
-        "Name": "x1"
+    Status: 'Optimal',
+    ObjectiveValue: 46,
+    Columns: {
+      x1: {
+        Index: 0,
+        Status: 'UB',
+        Lower: 0,
+        Upper: 40,
+        Type: 'Continuous',
+        Primal: 40,
+        Dual: 1,
+        Name: 'x1'
       },
-      "x2": {
-        "Index": 1,
-        "Status": "UB",
-        "Lower": 2,
-        "Type": "Continuous",
-        "Upper": 3,
-        "Primal": 3,
-        "Dual": 2,
-        "Name": "x2"
+      x2: {
+        Index: 1,
+        Status: 'UB',
+        Lower: 2,
+        Type: 'Continuous',
+        Upper: 3,
+        Primal: 3,
+        Dual: 2,
+        Name: 'x2'
       }
     },
-    "Rows": [],
-  })
-
+    Rows: []
+  });
 }
-
 
 /**
  * @param {import("../types").Highs} Module
@@ -232,7 +231,7 @@ End`);
       a: {
         Index: 0,
         Lower: 0,
-        Status: "BS",
+        Status: 'BS',
         Type: 'Continuous',
         Upper: Infinity,
         Primal: 10,
@@ -242,7 +241,7 @@ End`);
       b: {
         Index: 1,
         Lower: 0,
-        Status: "LB",
+        Status: 'LB',
         Type: 'Continuous',
         Upper: Infinity,
         Primal: 0,
@@ -250,24 +249,22 @@ End`);
         Name: 'b'
       }
     },
-    Rows: [{ Index: 0, Lower: 10, Upper: Infinity, Primal: 10, Dual: 11, Status: "LB", Name: 'c1' }]
+    Rows: [{ Index: 0, Lower: 10, Upper: Infinity, Primal: 10, Dual: 11, Status: 'LB', Name: 'c1' }]
   });
 }
-
 
 /**
  * @param {import("../types").Highs} Module
  */
 function test_quadratic_program_not_positive_semidefinite(Module) {
-  assert.throws(
-    (_) => Module.solve(`Maximize
+  assert.throws(_ =>
+    Module.solve(`Maximize
   obj: [x1^2]/2
  Bounds
   0 <= x1 <= 40
  End`)
   );
 }
-
 
 /**
  * @param {import("../types").Highs} Module
@@ -292,12 +289,9 @@ function test_infeasible(Module) {
         Name: 'a'
       }
     },
-    Rows: [
-      { Index: 0, Lower: 1, Upper: Infinity, Name: 'HiGHS_R0' }
-    ]
+    Rows: [{ Index: 0, Lower: 1, Upper: Infinity, Name: 'HiGHS_R0' }]
   });
 }
-
 
 /**
  * @param {import("../types").Highs} Module
@@ -324,12 +318,9 @@ end`);
         Name: 'a'
       }
     },
-    Rows: [
-      { Index: 0, Lower: 1, Upper: Infinity, Name: 'HiGHS_R0' }
-    ]
+    Rows: [{ Index: 0, Lower: 1, Upper: Infinity, Name: 'HiGHS_R0' }]
   });
 }
-
 
 /**
  * @param {import("../types").Highs} Module
@@ -354,11 +345,9 @@ function test_unbounded(Module) {
         Name: 'a'
       }
     },
-    Rows: [{ Index: 0, Status: 'LB', Lower: 1, Upper: Infinity, Primal: 1, Dual: 1, Name: 'HiGHS_R0' }
-    ]
+    Rows: [{ Index: 0, Status: 'LB', Lower: 1, Upper: Infinity, Primal: 1, Dual: 1, Name: 'HiGHS_R0' }]
   });
 }
-
 
 /**
  * @param {import("../types").Highs} Module
@@ -410,12 +399,11 @@ End`);
   });
 }
 
-
 /**
  * @param {import("../types").Highs} Module
  */
 function test_big(Module) {
-  const pb = fs.readFileSync(__dirname + "/life_goe.mod.lp");
+  const pb = fs.readFileSync(__dirname + '/life_goe.mod.lp');
   Module.solve(pb);
 }
 
@@ -446,7 +434,7 @@ async function test() {
   test_read_model_warning(Module);
   test_big(Module);
   test_many_solves(Module);
-  console.log("test succeeded");
+  console.log('test succeeded');
 }
 
-test()
+test();

--- a/types.d.ts
+++ b/types.d.ts
@@ -5,290 +5,562 @@ type Highs = {
 type HighsOptions = Readonly<
   Partial<{
     /**
-     * default: "choose"
+     * @default "choose"
      */
-    presolve: "off" | "choose" | "on";
+    presolve: 'off' | 'choose' | 'on';
 
     /**
-     * default: "choose"
+     * Solver option: "simplex", "choose", "ipm" or "pdlp". If
+     * "simplex"/"ipm"/"pdlp" is chosen then, for a MIP (QP) the
+     * integrality
+     * constraint (quadratic term) will be ignored
+     * @default "choose"
      */
-    solver: "simplex" | "choose" | "ipm";
+    solver: 'simplex' | 'choose' | 'ipm' | 'pdlp';
 
     /**
-     * default: "choose"
+     * Parallel option: "off", "choose" or "on"
+     * @default "choose"
      */
-    parallel: "off" | "choose" | "on";
+    parallel: 'off' | 'choose' | 'on';
 
     /**
-     * Time limit
-     * default: inf
+     * Run IPM crossover: "off", "choose" or "on"
+     * @default "on"
+     */
+    run_crossover: 'off' | 'choose' | 'on';
+
+    /**
+     * Time limit (seconds)
+     * @default Number.POSITIVE_INFINITY
      */
     time_limit: number;
 
     /**
-     * Compute cost, bound, RHS and basic solution ranging.
-     * default: "off"
+     * Compute cost, bound, RHS and basic solution ranging: "off" or "on"
+     * @default "off"
      */
-    ranging: "off" | "on";
+    ranging: 'off' | 'on';
 
     /**
-     * Limit on cost coefficient: values larger than this will be treated as infinite
-     * default: 1e+20
+     * Limit on |cost coefficient|: values greater than or equal to
+     * this will be treated as infinite
+     * @min 1e+15
+     * @default 1e+20
      */
     infinite_cost: number;
 
     /**
-     * Limit on |constraint bound|: values larger than this will be treated as infinite
-     * default: 1e+20
+     * Limit on |constraint bound|: values greater than or equal to
+     * this will be treated as infinite
+     * @min 1e+15
+     * @default 1e+20
      */
     infinite_bound: number;
 
     /**
-     * Lower limit on |matrix entries|: values smaller than this will be treated as zero
-     * default: 1e-09
+     * Lower limit on |matrix entries|: values less than or equal to this
+     * will be
+     * treated as zero
+     * @min 1e-12
+     * @default 1e-09
      */
     small_matrix_value: number;
 
     /**
-     * Upper limit on |matrix entries|: values larger than this will be treated as infinite
-     * default: 1e+15
+     * Upper limit on |matrix entries|: values greater than or equal to
+     * this will be treated as infinite
+     * @min 1e+00
+     * @default 1e+15
      */
     large_matrix_value: number;
 
     /**
      * Primal feasibility tolerance
-     * default: 1e-07
+     * @min 1e-10
+     * @default 1e-07
      */
     primal_feasibility_tolerance: number;
 
     /**
      * Dual feasibility tolerance
-     * default: 1e-07
+     * @min 1e-10
+     * @default 1e-07
      */
     dual_feasibility_tolerance: number;
 
     /**
      * IPM optimality tolerance
-     * default: 1e-08
+     * @min 1e-12
+     * @default 1e-08
      */
     ipm_optimality_tolerance: number;
 
     /**
-     * Objective bound for termination
-     * default: inf
+     * Objective bound for termination of the dual simplex solver
+     * @default Number.POSITIVE_INFINITY
      */
     objective_bound: number;
 
     /**
-     * Objective target for termination
-     * default: -inf
+     * Objective target for termination of the MIP solver
+     * @default Number.NEGATIVE_INFINITY
      */
     objective_target: number;
 
     /**
      * random seed used in HiGHS
-     * default: 0
+     * @min 0
+     * @default 0
      */
     random_seed: number;
 
     /**
      * number of threads used by HiGHS (0: automatic)
-     * default: 0
+     * @min 0
+     * @default 0
      */
     threads: number;
 
     /**
-     * Debugging level in HiGHS
-     * default: 0
+     * Exponent of power-of-two bound scaling for model
+     * @default 0
      */
-    highs_debug_level: number;
+    user_bound_scale: number;
+
+    /**
+     * Exponent of power-of-two cost scaling for model
+     * @default 0
+     */
+    user_cost_scale: number;
+
+    /**
+     * Debugging level in HiGHS
+     * @default 0
+     */
+    highs_debug_level: HighsDebugLevel;
 
     /**
      * Analysis level in HiGHS
-     * default: 0
+     * @default 0
      */
-    highs_analysis_level: number;
+    highs_analysis_level: HighsAnalysisLevel;
 
     /**
-     * Strategy for simplex solver
-     * default: 1
+     * Strategy for simplex solver 0 => Choose; 1 => Dual (serial); 2 =>
+     * Dual (PAMI); 3 => Dual (SIP); 4 => Primal
+     * @default 1
      */
-    simplex_strategy: number;
+    simplex_strategy: SimplexStrategy;
 
     /**
      * Simplex scaling strategy: off / choose / equilibration / forced equilibration / max value 0 / max value 1 (0/1/2/3/4/5)
-     * default: 1
+     * @default 1
      */
-    simplex_scale_strategy: number;
+    simplex_scale_strategy: SimplexScaleStrategy;
 
     /**
      * Strategy for simplex crash: off / LTSSF / Bixby (0/1/2)
-     * default: 0
+     * @default 0
      */
-    simplex_crash_strategy: number;
+    simplex_crash_strategy: SimplexCrashStrategy;
 
     /**
      * Strategy for simplex dual edge weights: Choose / Dantzig / Devex / Steepest Edge (-1/0/1/2)
-     * default: -1
+     * @default -1
      */
-    simplex_dual_edge_weight_strategy: number;
+    simplex_dual_edge_weight_strategy: SimplexEdgeWeightStrategy;
 
     /**
      * Strategy for simplex primal edge weights: Choose / Dantzig / Devex (-1/0/1)
-     * default: -1
+     * @default -1
      */
-    simplex_primal_edge_weight_strategy: number;
+    simplex_primal_edge_weight_strategy: SimplexEdgeWeightStrategy;
 
     /**
-     * Iteration limit for simplex solver
-     * default: 2147483647
+     * Iteration limit for simplex solver when solving LPs, but not
+     * subproblems in the MIP solver
+     * @min 0
+     * @default Number.MAX_SAFE_INTEGER
      */
     simplex_iteration_limit: number;
 
     /**
      * Limit on the number of simplex UPDATE operations
-     * default: 5000
+     * @min 0
+     * @default 5000
      */
     simplex_update_limit: number;
 
     /**
-     * Iteration limit for IPM solver
-     * default: 2147483647
-     */
-    ipm_iteration_limit: number;
-
-    /**
      * Minimum level of concurrency in parallel simplex
-     * default: 1
+     * @min 0
+     * @default 1
+     * @max 8
      */
     simplex_min_concurrency: number;
 
     /**
      * Maximum level of concurrency in parallel simplex
-     * default: 8
+     * @min 1
+     * @default 8
+     * @max 8
      */
     simplex_max_concurrency: number;
 
     /**
      * Enables or disables solver output
-     * default: true
+     * @default true
      */
     output_flag: boolean;
 
     /**
      * Enables or disables console logging
-     * default: true
+     * @default true
      */
     log_to_console: boolean;
 
     /**
      * Solution file
-     * default: ""
+     * @default ""
      */
     solution_file: string;
 
     /**
      * Log file
-     * default: "Highs.log"
+     * @default ""
      */
     log_file: string;
 
     /**
      * Write the primal and dual solution to a file
-     * default: false
+     * @default false
      */
     write_solution_to_file: boolean;
 
     /**
-     * Write the solution in style: 0=>Raw (computer-readable); 1=>Pretty (human-readable)
-     * default: 0
+     * Style of solution file (raw = computer-readable,
+     * pretty = human-readable):
+     * -1 => HiGHS old raw (deprecated); 0 => HiGHS raw;
+     * 1 => HiGHS pretty; 2 => Glpsol raw; 3 => Glpsol pretty;
+     * 4 => HiGHS sparse raw
+     * @default 0
      */
-    write_solution_style: number;
+    write_solution_style: SolutionStyle;
 
     /**
-     * Whether symmetry should be detected
-     * default: true
+     * Location of cost row for Glpsol file:
+     * -2 => Last; -1 => None; 0 => None if empty, otherwise data file
+     * location; 1 <= n <= num_row => Location n; n >
+     * num_row => Last
+     */
+    glpsol_cost_row_location: GlpsolCostRowLocation | number;
+
+    /**
+     * Run iCrash
+     * @default false
+     */
+    icrash: boolean;
+
+    /**
+     * Dualize strategy for iCrash
+     * @default false
+     */
+    icrash_dualize: boolean;
+
+    /**
+     * Strategy for iCrash
+     * @default "ICA"
+     */
+    icrash_strategy: string;
+
+    /**
+     * iCrash starting weight
+     * @min 1e-10
+     * @default 1e-03
+     * @max 1e50
+     */
+    icrash_starting_weight: number;
+
+    /**
+     * iCrash iterations
+     * @min 0
+     * @default 30
+     * @max 200
+     */
+    icrash_iterations: number;
+
+    /**
+     * iCrash approximate minimization iterations
+     * @min 0
+     * @default 50
+     * @max 100
+     */
+    icrash_approx_iter: number;
+
+    /**
+     * Exact subproblem solution for iCrash
+     * @default false
+     */
+    icrash_exact: boolean;
+
+    /**
+     * Exact subproblem solution for iCrash
+     * @default false
+     */
+    icrash_breakpoints: boolean;
+
+    /**
+     * Write model file
+     * @default ""
+     */
+    write_model_file: string;
+
+    /**
+     * Write the model to a file
+     * @default false
+     */
+    write_model_to_file: boolean;
+
+    /**
+     * Write presolved model file
+     * @default ""
+     */
+    write_presolved_model_file: string;
+
+    /**
+     * Write the presolved model to a file
+     * @default false
+     */
+    write_presolved_model_to_file: boolean;
+
+    /**
+     * Whether MIP symmetry should be detected
+     * @default true
      */
     mip_detect_symmetry: boolean;
 
     /**
+     * Whether MIP restart is permitted
+     * @default true
+     */
+    mip_allow_restart: boolean;
+
+    /**
      * MIP solver max number of nodes
-     * default: 2147483647
+     * @default Number.MAX_SAFE_INTEGER
      */
     mip_max_nodes: number;
 
     /**
      * MIP solver max number of nodes where estimate is above cutoff bound
-     * default: 2147483647
+     * @min 0
+     * @default Number.MAX_SAFE_INTEGER
      */
     mip_max_stall_nodes: number;
 
     /**
+     * MIP solver max number of nodes when completing a partial MIP start
+     * @min 0
+     * @default 500
+     */
+    mip_max_start_nodes: number;
+
+    // #ifdef HIGHS_DEBUGSOL
+    //   /**
+    //    * Solution file for debug solution of the MIP solver
+    //    * @default ""
+    //    */
+    //   mip_debug_solution_file: string;
+    // #endif
+
+    /**
+     * Whether improving MIP solutions should be saved
+     * @default false
+     */
+    mip_improving_solution_save: boolean;
+
+    /**
+     * Whether improving MIP solutions should be reported in sparse format
+     * @default false
+     */
+    mip_improving_solution_report_sparse: boolean;
+
+    /**
+     * File for reporting improving MIP solutions: not reported for an empty
+     * string \"\"
+     * @default ""
+     */
+    mip_improving_solution_file: string;
+
+    /**
      * MIP solver max number of leave nodes
-     * default: 2147483647
+     * @min 0
+     * @default Number.MAX_SAFE_INTEGER
      */
     mip_max_leaves: number;
 
     /**
-     * maximal age of dynamic LP rows before they are removed from the LP relaxation
-     * default: 10
+     * Limit on the number of improving solutions found to stop the MIP
+     * solver prematurely
+     * @min 1
+     * @default Number.MAX_SAFE_INTEGER
+     */
+    mip_max_improving_sols: number;
+
+    /**
+     * maximal age of dynamic LP rows before they are removed from the LP relaxation in the MIP solver
+     * @min 0
+     * @default 10
+     * @max 32767
      */
     mip_lp_age_limit: number;
 
     /**
-     * maximal age of rows in the cutpool before they are deleted
-     * default: 30
+     * maximal age of rows in the MIP solver cutpool before they are deleted
+     * @min 0
+     * @default 30
+     * @max 1000
      */
     mip_pool_age_limit: number;
 
     /**
-     * soft limit on the number of rows in the cutpool for dynamic age adjustment
-     * default: 10000
+     * soft limit on the number of rows in the MIP solver cutpool for dynamic age adjustment
+     * @min 1
+     * @default 10000
      */
     mip_pool_soft_limit: number;
 
     /**
-     * minimal number of observations before pseudo costs are considered reliable
-     * default: 8
+     * minimal number of observations before MIP solver pseudo costs are considered reliable
+     * @min 0
+     * @default 8
      */
     mip_pscost_minreliable: number;
 
     /**
+     * Minimal number of entries in the MIP solver cliquetable before
+     * neighbourhood
+     * queries of the conflict graph use parallel processing
+     * @min 0
+     * @default 100000
+     */
+    mip_min_cliquetable_entries_for_parallelism: number;
+
+    /**
      * MIP solver reporting level
-     * default: 1
+     * @min 0
+     * @default 1
+     * @max 2
      */
     mip_report_level: number;
 
     /**
      * MIP feasibility tolerance
-     * default: 1e-06
+     * @min 1e-10
+     * @default 1e-06
      */
     mip_feasibility_tolerance: number;
 
     /**
-     * effort spent for MIP heuristics
-     * default: 0.05
+     * Effort spent for MIP heuristics
+     * @min 0
+     * @default 0.05
+     * @max 1
      */
     mip_heuristic_effort: number;
+
+    /**
+     * Tolerance on relative gap, |ub-lb|/|ub|, to determine whether
+     * optimality has been reached for a MIP instance
+     * @min 0
+     * @default 1e-04
+     */
+    mip_rel_gap: number;
+
+    /**
+     * Tolerance on absolute gap of MIP, |ub-lb|, to determine whether
+     * optimality has been reached for a MIP instance
+     * @min 0
+     * @default 1e-06
+     */
+    mip_abs_gap: number;
+
+    /**
+     * MIP minimum logging interval
+     * @min 0
+     * @default 5
+     */
+    mip_min_logging_interval: number;
+
+    /**
+     * Iteration limit for IPM solver
+     * @default Number.MAX_SAFE_INTEGER
+     */
+    ipm_iteration_limit: number;
+
+    /**
+     * Use native termination for PDLP solver: Default = false
+     * @default false
+     */
+    pdlp_native_termination: boolean;
+
+    /**
+     * Scaling option for PDLP solver: Default = true
+     * @default true
+     */
+    pdlp_scaling: boolean;
+
+    /**
+     * Iteration limit for PDLP solver
+     * @min 0
+     */
+    pdlp_iteration_limit: number;
+
+    /**
+     * Restart mode for PDLP solver: 0 => none;
+     * 1 => GPU (default); 2 => CPU
+     * @min 0
+     * @default 1
+     * @max 2
+     */
+    pdlp_e_restart_method: number;
+
+    /**
+     * Duality gap tolerance for PDLP solver: Default = 1e-4
+     * @min 1e-12
+     * @default 1e-04
+     */
+    pdlp_d_gap_tol: number;
+
+    /**
+     * Iteration limit for QP solver
+     * @min 0
+     * @default Number.MAX_SAFE_INTEGER
+     */
+    qp_iteration_limit: number;
+
+    /**
+     * Nullspace limit for QP solver
+     * @min 0
+     * @default 4000
+     */
+    qp_nullspace_limit: number;
+
+    /**
+     * Strategy for IIS calculation:
+     * Prioritise rows (default) /
+     * Prioritise columns
+     * (0/1)
+     * @default 0
+     */
+    iis_strategy: IisStrategy;
   }>
 >;
 type HighsSolution =
-  | GenericHighsSolution<
-    true,
-    HighsLinearSolutionColumn,
-    HighsLinearSolutionRow
-  >
-  | GenericHighsSolution<
-    false,
-    HighsMixedIntegerLinearSolutionColumn,
-    HighsMixedIntegerLinearSolutionRow
-  >
-  | GenericHighsSolution<
-    boolean,
-    HighsInfeasibleSolutionColumn,
-    HighsInfeasibleSolutionRow,
-    "Infeasible"
-  >;
+  | GenericHighsSolution<true, HighsLinearSolutionColumn, HighsLinearSolutionRow>
+  | GenericHighsSolution<false, HighsMixedIntegerLinearSolutionColumn, HighsMixedIntegerLinearSolutionRow>
+  | GenericHighsSolution<boolean, HighsInfeasibleSolutionColumn, HighsInfeasibleSolutionRow, 'Infeasible'>;
 
 type GenericHighsSolution<IsLinear extends boolean, ColType, RowType, Status extends HighsModelStatus = HighsModelStatus> = {
   Status: Status;
@@ -298,22 +570,22 @@ type GenericHighsSolution<IsLinear extends boolean, ColType, RowType, Status ext
 };
 
 type HighsModelStatus =
-  | "Not Set"
-  | "Load error"
-  | "Model error"
-  | "Presolve error"
-  | "Solve error"
-  | "Postsolve error"
-  | "Empty"
-  | "Optimal"
-  | "Infeasible"
-  | "Primal infeasible or unbounded"
-  | "Unbounded"
-  | "Bound on objective reached"
-  | "Target for objective reached"
-  | "Time limit reached"
-  | "Iteration limit reached"
-  | "Unknown";
+  | 'Not Set'
+  | 'Load error'
+  | 'Model error'
+  | 'Presolve error'
+  | 'Solve error'
+  | 'Postsolve error'
+  | 'Empty'
+  | 'Optimal'
+  | 'Infeasible'
+  | 'Primal infeasible or unbounded'
+  | 'Unbounded'
+  | 'Bound on objective reached'
+  | 'Target for objective reached'
+  | 'Time limit reached'
+  | 'Iteration limit reached'
+  | 'Unknown';
 
 interface HighsInfeasibleSolutionBase {
   Index: number;
@@ -321,9 +593,9 @@ interface HighsInfeasibleSolutionBase {
   Upper: number | null;
 }
 
-interface HighsInfeasibleSolutionRow extends HighsInfeasibleSolutionBase { }
+interface HighsInfeasibleSolutionRow extends HighsInfeasibleSolutionBase {}
 interface HighsInfeasibleSolutionColumn extends HighsInfeasibleSolutionBase {
-  Type: "Integer" | "Continuous"
+  Type: 'Integer' | 'Continuous';
 }
 
 interface HighsSolutionBase extends HighsInfeasibleSolutionBase {
@@ -337,7 +609,7 @@ interface HighsLinearSolutionColumn extends HighsSolutionBase {
 }
 
 interface HighsMixedIntegerLinearSolutionColumn extends HighsSolutionBase {
-  Type: "Integer" | "Continuous";
+  Type: 'Integer' | 'Continuous';
   Name: string;
 }
 
@@ -347,21 +619,21 @@ interface HighsLinearSolutionRow extends HighsSolutionBase {
   Name: string;
 }
 
-interface HighsMixedIntegerLinearSolutionRow extends HighsSolutionBase { }
+interface HighsMixedIntegerLinearSolutionRow extends HighsSolutionBase {}
 
 type HighsBasisStatus =
   /** Fixed */
-  | "FX"
+  | 'FX'
   /** Lower Bound */
-  | "LB"
+  | 'LB'
   /** Basis */
-  | "BS"
+  | 'BS'
   /** Upper Bound */
-  | "UB"
+  | 'UB'
   /** Free */
-  | "FR"
+  | 'FR'
   /** Non-Bounded */
-  | "NB";
+  | 'NB';
 
 type HighsLoaderOptions = Readonly<
   Partial<{
@@ -370,9 +642,108 @@ type HighsLoaderOptions = Readonly<
   }>
 >;
 
+enum HighsAnalysisLevel {
+  kHighsAnalysisLevelNone = 0,
+  kHighsAnalysisLevelModelData = 1,
+  kHighsAnalysisLevelSolverSummaryData = 2,
+  kHighsAnalysisLevelSolverRuntimeData = 4,
+  kHighsAnalysisLevelSolverTime = 8,
+  kHighsAnalysisLevelNlaData = 16,
+  kHighsAnalysisLevelNlaTime = 32,
+  kHighsAnalysisLevelMin = kHighsAnalysisLevelNone,
+  kHighsAnalysisLevelMax = kHighsAnalysisLevelModelData +
+    kHighsAnalysisLevelSolverSummaryData +
+    kHighsAnalysisLevelSolverRuntimeData +
+    kHighsAnalysisLevelSolverTime +
+    kHighsAnalysisLevelNlaData +
+    kHighsAnalysisLevelNlaTime
+}
+
+enum HighsDebugLevel {
+  kHighsDebugLevelNone = 0,
+  kHighsDebugLevelCheap,
+  kHighsDebugLevelCostly,
+  kHighsDebugLevelExpensive,
+  kHighsDebugLevelMin = kHighsDebugLevelNone,
+  kHighsDebugLevelMax = kHighsDebugLevelExpensive
+}
+
+enum SimplexScaleStrategy {
+  kSimplexScaleStrategyMin = 0,
+  kSimplexScaleStrategyOff = kSimplexScaleStrategyMin, // 0
+  kSimplexScaleStrategyChoose, // 1
+  kSimplexScaleStrategyEquilibration, // 2
+  kSimplexScaleStrategyForcedEquilibration, // 3
+  kSimplexScaleStrategyMaxValue015, // 4
+  kSimplexScaleStrategyMaxValue0157, // 5
+  kSimplexScaleStrategyMax = kSimplexScaleStrategyMaxValue0157
+}
+
+enum SimplexStrategy {
+  kSimplexStrategyMin = 0,
+  kSimplexStrategyChoose = kSimplexStrategyMin, // 0
+  kSimplexStrategyDual, // 1
+  kSimplexStrategyDualPlain = kSimplexStrategyDual, // 1
+  kSimplexStrategyDualTasks, // 2
+  kSimplexStrategyDualMulti, // 3
+  kSimplexStrategyPrimal, // 4
+  kSimplexStrategyMax = kSimplexStrategyPrimal,
+  kSimplexStrategyNum
+}
+
+enum SimplexCrashStrategy {
+  kSimplexCrashStrategyMin = 0,
+  kSimplexCrashStrategyOff = kSimplexCrashStrategyMin,
+  kSimplexCrashStrategyLtssfK,
+  kSimplexCrashStrategyLtssf = kSimplexCrashStrategyLtssfK,
+  kSimplexCrashStrategyBixby,
+  kSimplexCrashStrategyLtssfPri,
+  kSimplexCrashStrategyLtsfK,
+  kSimplexCrashStrategyLtsfPri,
+  kSimplexCrashStrategyLtsf,
+  kSimplexCrashStrategyBixbyNoNonzeroColCosts,
+  kSimplexCrashStrategyBasic,
+  kSimplexCrashStrategyTestSing,
+  kSimplexCrashStrategyMax = kSimplexCrashStrategyTestSing
+}
+
+enum SimplexEdgeWeightStrategy {
+  kSimplexEdgeWeightStrategyMin = -1,
+  kSimplexEdgeWeightStrategyChoose = kSimplexEdgeWeightStrategyMin,
+  kSimplexEdgeWeightStrategyDantzig,
+  kSimplexEdgeWeightStrategyDevex,
+  kSimplexEdgeWeightStrategySteepestEdge,
+  kSimplexEdgeWeightStrategyMax = kSimplexEdgeWeightStrategySteepestEdge
+}
+
+enum SolutionStyle {
+  kSolutionStyleOldRaw = -1,
+  kSolutionStyleRaw = 0,
+  kSolutionStylePretty, // 1;
+  kSolutionStyleGlpsolRaw, // 2;
+  kSolutionStyleGlpsolPretty, // 3;
+  kSolutionStyleSparse, // 4;
+  kSolutionStyleMin = kSolutionStyleOldRaw,
+  kSolutionStyleMax = kSolutionStyleSparse
+}
+
+enum GlpsolCostRowLocation {
+  kGlpsolCostRowLocationLast = -2,
+  kGlpsolCostRowLocationNone, // -1
+  kGlpsolCostRowLocationNoneIfEmpty, // 0
+  kGlpsolCostRowLocationMin = kGlpsolCostRowLocationLast
+}
+
+enum IisStrategy {
+  kIisStrategyMin = 0,
+  kIisStrategyFromLpRowPriority = kIisStrategyMin,  // 0
+  kIisStrategyFromLpColPriority,                    // 1
+  //  kIisStrategyFromRayRowPriority,                     // 2
+  //  kIisStrategyFromRayColPriority,                     // 3
+  kIisStrategyMax = kIisStrategyFromLpColPriority
+};
+
 /** Loads HiGHS */
-export default function highsLoader(
-  options?: HighsLoaderOptions
-): Promise<Highs>;
+export default function highsLoader(options?: HighsLoaderOptions): Promise<Highs>;
 
 // export const Model: unknown


### PR DESCRIPTION
This PR includes the following:
- an update of HiGHS to v1.8.0 (latest)
- an update of emscripten to v3.1.71 (latest)
- an update to the typings to include more (probably new?) HiGHS options

To make it work, the following additional changes were made:
- updates to the VSCode dev container definition to use a newer base image (Node 20, Debian Bookworm) and install the latest emscripten version
- updates to the build.sh script to remove deprecated build variables, rename changed ones and add a new one. Additionally renamed deprected emscripten option EXTRA_EXPORTED_LIBS to EXPORTED_LIBS
- Updates to the post.js script to auto-assume a Type of `Continuous` if no type is parsed from the output (HiGHS v1.8.0 does not include "type" column if all model variables are continuous)
- Updates to the CI and Release pipelines to update all used actions to their latest versions and use emscripten v3.1.71
- Update to test.js: the test `test_empty_model` caused HiGHS v1.8.0 to (correctly) throw a model read error. The test was updated to test against a valid empty model (the objective function being a constant).

If desired, the `test_empty_model` test can also be modified to assure that a model of `blah blah not a good file` throws a read error, but since there is already a test for invalid files i chose to modify it to test a valid empty model instead.

The option typings update does not fix #31 (yet) since those come below https://github.com/ERGO-Code/HiGHS/blob/v1.8.0/src/lp_data/HighsOptions.h#L1123 (where i stopped adding option typings for now).
Maybe if i find the time, i will also add typings for *all* advanced options.