### PR TITLE
Bump HiGHS to v1.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "highs",
-  "version": "1.14.2",
+  "version": "1.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "highs",
-      "version": "1.14.2",
+      "version": "1.15.1",
       "license": "MIT",
       "devDependencies": {
         "@tsconfig/recommended": "^1.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "highs",
-  "version": "1.14.2",
+  "version": "1.15.1",
   "description": "Mixed integer linear programming library, built by compiling a high-performance C++ solver developed by the University of Edinburgh (HiGHS) to WebAssembly.",
   "main": "build/highs.js",
   "type": "commonjs",

--- a/tests/test.js
+++ b/tests/test.js
@@ -441,6 +441,31 @@ function test_exceeds_stack(Module) {
   Module.solve(pb);
 }
 
+/**
+ * @param {import("../types").Highs} Module
+ */
+function test_mip_presolve_is_not_suboptimal(Module) {
+  // See https://github.com/lovasoa/highs-js/issues/53
+  // HiGHS 1.14.0 presolved this to x=0, z=5 (objective 15) and reported it as
+  // "Optimal". The optimum is x=4.5, z=0 (objective 9). Since the status was
+  // "Optimal" either way, a caller had no way to detect the wrong answer.
+  const pb = `Minimize
+ obj: 2 x + 3 z
+Subject To
+ c1: x + z >= 4.5
+Bounds
+ x <= 10
+ z <= 10
+General
+ z
+End`;
+  const sol = Module.solve(pb);
+  assert.strictEqual(sol.Status, 'Optimal');
+  assert.strictEqual(sol.ObjectiveValue, 9);
+  // The invariant that actually broke: presolve must not change the optimum.
+  assert.deepStrictEqual(sol, Module.solve(pb, { presolve: 'off' }));
+}
+
 
 async function test() {
   const Module = await highs();
@@ -460,6 +485,7 @@ async function test() {
   test_big(Module);
   test_many_solves(Module);
   test_exceeds_stack(Module);
+  test_mip_presolve_is_not_suboptimal(Module);
   await test_print_callback();
   console.log('test succeeded');
 }


### PR DESCRIPTION
Fixes #53.

The bundled core (v1.14.0) has a MIP presolve regression: it reports suboptimal solutions with `Status: "Optimal"`, so callers cannot detect the wrong answer. Fixed upstream by ERGO-Code/HiGHS#2961, which first ships in v1.15.0.

Changes:
- `HiGHS` submodule `v1.14.0` -> `v1.15.1`
- regression test for #53
- `package.json` `1.14.2` -> `1.15.1`, to keep the version correspondence the README documents (`1.14.x` contains HiGHS `v1.14.x`). Drop this if you would rather bump it at release time.

Verified locally with `npm run build && npm test`:

| bundled core | objective on the #53 model |
|---|---|
| v1.14.0 (current) | 15, reported Optimal |
| v1.15.1 (this PR) | 9 |

The optimum is 9. The new test fails against the current submodule and passes against v1.15.1, so it is a real regression test rather than a description of current behaviour. It asserts the invariant that actually broke: presolve must not change the optimum.

Full suite passes.