### PR TITLE
expose results from getRanging when `ranging: 'on'`

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,30 @@ The problem has to be passed in the [CPLEX .lp file format](http://web.mit.edu/l
 
 For a more complete example, see the [`demo`](./demo/) folder.
 
+### Ranging (sensitivity analysis)
+
+Passing the `ranging: 'on'` option adds a `Ranging` field to the returned
+solution, exposing the results of HiGHS's `getRanging` method: cost, column
+bound and row bound ranging.
+
+```js
+const sol = highs.solve(PROBLEM, { ranging: 'on' });
+console.log(sol.Ranging);
+// {
+//   cost: [ /* one record per column */ ],
+//   column_bound: [ /* one record per column */ ],
+//   row_bound: [ /* one record per row */ ]
+// }
+```
+
+Each record describes how far the cost or bound can move up and down before the
+optimal basis changes (`up_value`/`dn_value`), together with the resulting
+objective (`up_objective`/`dn_objective`) and the indices of the variables
+entering and leaving the basis at each limit (`up_in_variable`/`up_out_variable`
+and `dn_in_variable`/`dn_out_variable`; a negative index means no such
+variable). The `cost` and `column_bound` arrays are indexed by column, and
+`row_bound` by row, in the same order as `Columns` and `Rows`.
+
 ### Loading the wasm file
 
 This package requires a wasm file.

--- a/exported_functions.json
+++ b/exported_functions.json
@@ -10,5 +10,10 @@
   "_Highs_setStringOptionValue",
   "_Highs_setIntOptionValue",
   "_Highs_setDoubleOptionValue",
-  "_Highs_setBoolOptionValue"
+  "_Highs_setBoolOptionValue",
+  "_Highs_getNumCol",
+  "_Highs_getNumRow",
+  "_Highs_getRanging",
+  "_malloc",
+  "_free"
 ]

--- a/src/post.js
+++ b/src/post.js
@@ -135,7 +135,7 @@ function getRanging(highs) {
   const num_row = Highs_getNumRow(highs);
 
   // Each ranging record is made of four arrays: value and objective are
-  // doubles, in_var and ou_var are (32 bit) integers. Allocate one buffer per
+  // doubles, in_var and out_var are (32 bit) integers. Allocate one buffer per
   // array and remember how to read it back.
   const buffers = [];
   /**
@@ -166,14 +166,14 @@ function getRanging(highs) {
   /**
    * Allocate the four arrays that make up a single ranging record.
    * @param {number} length Number of entries (columns or rows)
-   * @returns {{value:number, objective:number, in_var:number, ou_var:number}}
+   * @returns {{value:number, objective:number, in_var:number, out_var:number}}
    */
   function allocRecord(length) {
     return {
       value: allocArray(length, "f64"),
       objective: allocArray(length, "f64"),
       in_var: allocArray(length, "i32"),
-      ou_var: allocArray(length, "i32"),
+      out_var: allocArray(length, "i32"),
     };
   }
 
@@ -189,12 +189,12 @@ function getRanging(highs) {
       () =>
         Highs_getRanging(
           highs,
-          col_cost_up.value, col_cost_up.objective, col_cost_up.in_var, col_cost_up.ou_var,
-          col_cost_dn.value, col_cost_dn.objective, col_cost_dn.in_var, col_cost_dn.ou_var,
-          col_bound_up.value, col_bound_up.objective, col_bound_up.in_var, col_bound_up.ou_var,
-          col_bound_dn.value, col_bound_dn.objective, col_bound_dn.in_var, col_bound_dn.ou_var,
-          row_bound_up.value, row_bound_up.objective, row_bound_up.in_var, row_bound_up.ou_var,
-          row_bound_dn.value, row_bound_dn.objective, row_bound_dn.in_var, row_bound_dn.ou_var
+          col_cost_up.value, col_cost_up.objective, col_cost_up.in_var, col_cost_up.out_var,
+          col_cost_dn.value, col_cost_dn.objective, col_cost_dn.in_var, col_cost_dn.out_var,
+          col_bound_up.value, col_bound_up.objective, col_bound_up.in_var, col_bound_up.out_var,
+          col_bound_dn.value, col_bound_dn.objective, col_bound_dn.in_var, col_bound_dn.out_var,
+          row_bound_up.value, row_bound_up.objective, row_bound_up.in_var, row_bound_up.out_var,
+          row_bound_dn.value, row_bound_dn.objective, row_bound_dn.in_var, row_bound_dn.out_var
         ),
       "compute ranging (requires an optimal basic solution)"
     );
@@ -202,8 +202,8 @@ function getRanging(highs) {
     /**
      * Turn a pair of up/down record pointers into an array of records, one per
      * column or row.
-     * @param {{value:number, objective:number, in_var:number, ou_var:number}} up
-     * @param {{value:number, objective:number, in_var:number, ou_var:number}} dn
+     * @param {{value:number, objective:number, in_var:number, out_var:number}} up
+     * @param {{value:number, objective:number, in_var:number, out_var:number}} dn
      * @param {number} length
      * @returns {import("../types").HighsRangingRecord[]}
      */
@@ -211,22 +211,22 @@ function getRanging(highs) {
       const up_value = readArray(up.value, length, "f64");
       const up_objective = readArray(up.objective, length, "f64");
       const up_in_var = readArray(up.in_var, length, "i32");
-      const up_ou_var = readArray(up.ou_var, length, "i32");
+      const up_out_var = readArray(up.out_var, length, "i32");
       const dn_value = readArray(dn.value, length, "f64");
       const dn_objective = readArray(dn.objective, length, "f64");
       const dn_in_var = readArray(dn.in_var, length, "i32");
-      const dn_ou_var = readArray(dn.ou_var, length, "i32");
+      const dn_out_var = readArray(dn.out_var, length, "i32");
       const records = new Array(length);
       for (let i = 0; i < length; i++) {
         records[i] = {
           "up_value": up_value[i],
           "up_objective": up_objective[i],
           "up_in_variable": up_in_var[i],
-          "up_out_variable": up_ou_var[i],
+          "up_out_variable": up_out_var[i],
           "dn_value": dn_value[i],
           "dn_objective": dn_objective[i],
           "dn_in_variable": dn_in_var[i],
-          "dn_out_variable": dn_ou_var[i],
+          "dn_out_variable": dn_out_var[i],
         };
       }
       return records;

--- a/src/post.js
+++ b/src/post.js
@@ -30,6 +30,21 @@ Module.Highs_writeSolutionPretty = Module["cwrap"](
   "number",
   ["number", "string"]
 );
+const Highs_getNumCol = Module["cwrap"]("Highs_getNumCol", "number", [
+  "number",
+]);
+const Highs_getNumRow = Module["cwrap"]("Highs_getNumRow", "number", [
+  "number",
+]);
+// Highs_getRanging takes the Highs pointer followed by 24 output array
+// pointers (6 ranging records, each made of a value, objective, in-variable
+// and out-variable array). See
+// https://github.com/ERGO-Code/HiGHS/blob/master/highs/interfaces/highs_c_api.h
+const Highs_getRanging = Module["cwrap"](
+  "Highs_getRanging",
+  "number",
+  ["number"].concat(new Array(24).fill("number"))
+);
 
 const MODEL_STATUS_CODES = /** @type {const} */ ({
   0: "Not Set",
@@ -56,6 +71,10 @@ var /** @type {()=>Highs} */ _Highs_create,
   /** @type {(arg0:Highs)=>void} */ _Highs_run,
   /** @type {(arg0:Highs)=>void} */ _Highs_destroy,
   /** @type {(arg0:Highs)=>(keyof (typeof MODEL_STATUS_CODES))} */ _Highs_getModelStatus,
+  /** @type {(size:number)=>number} */ _malloc,
+  /** @type {(ptr:number)=>void} */ _free,
+  /** @type {Float64Array} */ HEAPF64,
+  /** @type {Int32Array} */ HEAP32,
   /** @type {any}*/ FS;
 
 /**
@@ -96,11 +115,132 @@ Module["solve"] = function (model_str, highs_options) {
     "write and extract solution"
   );
   const solution = FS.readFile(SOLUTION_FILENAME, { encoding: "utf8" });
-  _Highs_destroy(highs);
   const output = parseResult(solution.split(/\r?\n/), status);
+  if (options["ranging"] === "on") {
+    output["Ranging"] = getRanging(highs);
+  }
+  _Highs_destroy(highs);
   FS.unlink(SOLUTION_FILENAME);
   return output;
 };
+
+/**
+ * Reads the ranging (sensitivity analysis) information for the last solved
+ * model out of the Highs instance by calling the Highs_getRanging C API.
+ * @param {Highs} highs A pointer to the Highs instance
+ * @returns {import("../types").HighsRanging} The ranging information
+ */
+function getRanging(highs) {
+  const num_col = Highs_getNumCol(highs);
+  const num_row = Highs_getNumRow(highs);
+
+  // Each ranging record is made of four arrays: value and objective are
+  // doubles, in_var and ou_var are (32 bit) integers. Allocate one buffer per
+  // array and remember how to read it back.
+  const buffers = [];
+  /**
+   * @param {number} length Number of elements the array should hold
+   * @param {"f64" | "i32"} kind The element type stored in the array
+   * @returns {number} The pointer to the freshly allocated array
+   */
+  function allocArray(length, kind) {
+    const bytes_per_element = kind === "f64" ? 8 : 4;
+    const ptr = _malloc(Math.max(1, length) * bytes_per_element);
+    buffers.push({ ptr, length, kind });
+    return ptr;
+  }
+  /**
+   * @param {number} ptr The pointer to read from
+   * @param {number} length Number of elements to read
+   * @param {"f64" | "i32"} kind The element type stored in the array
+   * @returns {number[]} The values read out of the WebAssembly heap
+   */
+  function readArray(ptr, length, kind) {
+    const heap = kind === "f64" ? HEAPF64 : HEAP32;
+    const shift = kind === "f64" ? 3 : 2;
+    const base = ptr >> shift;
+    const values = new Array(length);
+    for (let i = 0; i < length; i++) values[i] = heap[base + i];
+    return values;
+  }
+  /**
+   * Allocate the four arrays that make up a single ranging record.
+   * @param {number} length Number of entries (columns or rows)
+   * @returns {{value:number, objective:number, in_var:number, ou_var:number}}
+   */
+  function allocRecord(length) {
+    return {
+      value: allocArray(length, "f64"),
+      objective: allocArray(length, "f64"),
+      in_var: allocArray(length, "i32"),
+      ou_var: allocArray(length, "i32"),
+    };
+  }
+
+  const col_cost_up = allocRecord(num_col);
+  const col_cost_dn = allocRecord(num_col);
+  const col_bound_up = allocRecord(num_col);
+  const col_bound_dn = allocRecord(num_col);
+  const row_bound_up = allocRecord(num_row);
+  const row_bound_dn = allocRecord(num_row);
+
+  try {
+    assert_ok(
+      () =>
+        Highs_getRanging(
+          highs,
+          col_cost_up.value, col_cost_up.objective, col_cost_up.in_var, col_cost_up.ou_var,
+          col_cost_dn.value, col_cost_dn.objective, col_cost_dn.in_var, col_cost_dn.ou_var,
+          col_bound_up.value, col_bound_up.objective, col_bound_up.in_var, col_bound_up.ou_var,
+          col_bound_dn.value, col_bound_dn.objective, col_bound_dn.in_var, col_bound_dn.ou_var,
+          row_bound_up.value, row_bound_up.objective, row_bound_up.in_var, row_bound_up.ou_var,
+          row_bound_dn.value, row_bound_dn.objective, row_bound_dn.in_var, row_bound_dn.ou_var
+        ),
+      "compute ranging (requires an optimal basic solution)"
+    );
+
+    /**
+     * Turn a pair of up/down record pointers into an array of records, one per
+     * column or row.
+     * @param {{value:number, objective:number, in_var:number, ou_var:number}} up
+     * @param {{value:number, objective:number, in_var:number, ou_var:number}} dn
+     * @param {number} length
+     * @returns {import("../types").HighsRangingRecord[]}
+     */
+    function toRecords(up, dn, length) {
+      const up_value = readArray(up.value, length, "f64");
+      const up_objective = readArray(up.objective, length, "f64");
+      const up_in_var = readArray(up.in_var, length, "i32");
+      const up_ou_var = readArray(up.ou_var, length, "i32");
+      const dn_value = readArray(dn.value, length, "f64");
+      const dn_objective = readArray(dn.objective, length, "f64");
+      const dn_in_var = readArray(dn.in_var, length, "i32");
+      const dn_ou_var = readArray(dn.ou_var, length, "i32");
+      const records = new Array(length);
+      for (let i = 0; i < length; i++) {
+        records[i] = {
+          "up_value": up_value[i],
+          "up_objective": up_objective[i],
+          "up_in_variable": up_in_var[i],
+          "up_out_variable": up_ou_var[i],
+          "dn_value": dn_value[i],
+          "dn_objective": dn_objective[i],
+          "dn_in_variable": dn_in_var[i],
+          "dn_out_variable": dn_ou_var[i],
+        };
+      }
+      return records;
+    }
+
+    return {
+      "cost": toRecords(col_cost_up, col_cost_dn, num_col),
+      "column_bound": toRecords(col_bound_up, col_bound_dn, num_col),
+      "row_bound": toRecords(row_bound_up, row_bound_dn, num_row),
+    };
+  } finally {
+    for (const buffer of buffers) _free(buffer.ptr);
+  }
+}
 
 function setNumericOption(highs, option_name, option_value) {
   let result = Highs_setDoubleOptionValue(highs, option_name, option_value);

--- a/tests/test.js
+++ b/tests/test.js
@@ -467,6 +467,48 @@ End`;
 }
 
 
+/**
+ * @param {import("../types").Highs} Module
+ */
+function test_ranging(Module) {
+  // Passing `ranging: 'on'` exposes the results of HiGHS's Highs_getRanging
+  // (cost, column bound and row bound sensitivity analysis) on the solution.
+  const sol = Module.solve(PROBLEM, { ranging: 'on' });
+
+  // The rest of the solution is unchanged by requesting ranging.
+  const { Ranging, ...withoutRanging } = sol;
+  assert.deepStrictEqual(withoutRanging, SOLUTION);
+
+  assert.deepStrictEqual(Ranging, {
+    cost: [
+      { up_value: 2.4, up_objective: 112, up_in_variable: 3, up_out_variable: 3, dn_value: -4, dn_objective: 0, dn_in_variable: 5, dn_out_variable: 2 },
+      { up_value: 19.5, up_objective: 105, up_in_variable: 3, up_out_variable: 3, dn_value: -Infinity, dn_objective: -Infinity, dn_in_variable: -1, dn_out_variable: -1 },
+      { up_value: Infinity, up_objective: Infinity, up_in_variable: -1, up_out_variable: -1, dn_value: 1.9411764705882355, dn_objective: 53.529411764705884, dn_in_variable: 3, dn_out_variable: 3 },
+      { up_value: 9.75, up_objective: 105, up_in_variable: 3, up_out_variable: 3, dn_value: -Infinity, dn_objective: -Infinity, dn_in_variable: -1, dn_out_variable: -1 }
+    ],
+    column_bound: [
+      { up_value: 23.75, up_objective: 78.75, up_in_variable: 3, up_out_variable: 3, dn_value: 1, dn_objective: 5, dn_in_variable: 5, dn_out_variable: 2 },
+      { up_value: 1.5, up_objective: 78.75, up_in_variable: 3, up_out_variable: 3, dn_value: 1, dn_objective: 87.5, dn_in_variable: -1, dn_out_variable: -1 },
+      { up_value: 16.5, up_objective: 87.5, up_in_variable: -1, up_out_variable: -1, dn_value: 12.25, dn_objective: 78.75, dn_in_variable: 3, dn_out_variable: 3 },
+      { up_value: 3, up_objective: 78.75, up_in_variable: 3, up_out_variable: 3, dn_value: 0, dn_objective: 105, dn_in_variable: 3, dn_out_variable: 1 }
+    ],
+    row_bound: [
+      { up_value: 55, up_objective: 140, up_in_variable: 3, up_out_variable: 0, dn_value: -13, dn_objective: 38, dn_in_variable: -1, dn_out_variable: 2 },
+      { up_value: 75, up_objective: 200, up_in_variable: 5, up_out_variable: 0, dn_value: -3, dn_objective: 5, dn_in_variable: -1, dn_out_variable: 2 },
+      { up_value: 9, up_objective: 182, up_in_variable: 5, up_out_variable: 0, dn_value: -1, dn_objective: 77, dn_in_variable: 3, dn_out_variable: 1 }
+    ]
+  });
+}
+
+/**
+ * @param {import("../types").Highs} Module
+ */
+function test_no_ranging_by_default(Module) {
+  // Without the `ranging` option, no Ranging key is added to the result.
+  const sol = Module.solve(PROBLEM);
+  assert.strictEqual('Ranging' in sol, false);
+}
+
 async function test() {
   const Module = await highs();
   test_optimal(Module);
@@ -486,6 +528,8 @@ async function test() {
   test_many_solves(Module);
   test_exceeds_stack(Module);
   test_mip_presolve_is_not_suboptimal(Module);
+  test_ranging(Module);
+  test_no_ranging_by_default(Module);
   await test_print_callback();
   console.log('test succeeded');
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -567,6 +567,51 @@ type GenericHighsSolution<IsLinear extends boolean, ColType, RowType, Status ext
   ObjectiveValue: number;
   Columns: Record<string, ColType>;
   Rows: RowType[];
+  /**
+   * Cost, bound and RHS ranging (sensitivity analysis) information.
+   * Only present when the `ranging: 'on'` option is passed to `solve`.
+   */
+  Ranging?: HighsRanging;
+};
+
+/**
+ * Ranging (sensitivity analysis) information produced by HiGHS when the
+ * `ranging: 'on'` option is used. Each array is indexed by column or row in
+ * the same order as the model, matching the `Index` field of the
+ * corresponding entries in `Columns` and `Rows`.
+ */
+type HighsRanging = {
+  /** Objective coefficient (cost) ranging, one record per column. */
+  cost: HighsRangingRecord[];
+  /** Column bound ranging, one record per column. */
+  column_bound: HighsRangingRecord[];
+  /** Row bound (RHS) ranging, one record per row. */
+  row_bound: HighsRangingRecord[];
+};
+
+/**
+ * A single ranging record describing how far a cost or bound can move (up and
+ * down) before the optimal basis changes. `*_in_variable` / `*_out_variable`
+ * are the indices of the variables entering / leaving the basis at each limit
+ * (a negative value means no such variable).
+ */
+type HighsRangingRecord = {
+  /** Upper range of the value. */
+  up_value: number;
+  /** Objective value at the upper range. */
+  up_objective: number;
+  /** Index of the variable entering the basis at the upper range. */
+  up_in_variable: number;
+  /** Index of the variable leaving the basis at the upper range. */
+  up_out_variable: number;
+  /** Lower range of the value. */
+  dn_value: number;
+  /** Objective value at the lower range. */
+  dn_objective: number;
+  /** Index of the variable entering the basis at the lower range. */
+  dn_in_variable: number;
+  /** Index of the variable leaving the basis at the lower range. */
+  dn_out_variable: number;
 };
 
 type HighsModelStatus =


### PR DESCRIPTION
Generated with CoPilot:

Thanks!

---

HiGHS can compute cost/bound ranging (sensitivity analysis) via `Highs_getRanging`, but the results were never surfaced to JS callers. This adds a `Ranging` field to the `solve()` result when the `ranging: 'on'` option is passed.

```js
const sol = highs.solve(PROBLEM, { ranging: 'on' });
sol.Ranging;
// {
//   cost:         [ /* one record per column */ ],
//   column_bound: [ /* one record per column */ ],
//   row_bound:    [ /* one record per row */ ],
// }
// record: { up_value, up_objective, up_in_variable, up_out_variable,
//           dn_value, dn_objective, dn_in_variable, dn_out_variable }
```

### Changes
- **`src/post.js`**: after a successful solve with `ranging: 'on'`, allocate the 24 output arrays `Highs_getRanging` expects on the wasm heap, call it, marshal the results out of `HEAPF64`/`HEAP32` into the `Ranging` object, and free the buffers. Buffers are freed in a `finally`; the output is unchanged when the option is absent.
- **`exported_functions.json`**: export `Highs_getRanging`, `Highs_getNumCol`, `Highs_getNumRow`, plus `_malloc`/`_free` for heap allocation.
- **`types.d.ts`**: add `HighsRanging` / `HighsRangingRecord` and an optional `Ranging` field on the solution.
- **`tests/test.js`**: add `test_ranging` (full expected output for the sample LP) and `test_no_ranging_by_default`.
- **`README.md`**: document the option.

### Notes
- `cost`/`column_bound` are column-indexed and `row_bound` row-indexed, matching `Columns`/`Rows` order. `*_in_variable`/`*_out_variable` are variable indices (`-1` = none); infinite ranges surface as `±Infinity`.
- `Highs_getRanging` requires an optimal basic solution (LP); when it can't be computed, `solve()` throws, consistent with other HiGHS error handling.